### PR TITLE
Log to STDOUT, bump it up.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,10 +13,14 @@ RUN \
     libffi-dev \
 # for postgres gem
     libpq-dev \
-# updated SSL root certs
-    ca-certificates \
 # pretty much no asset pipeline without this
     nodejs
+
+# updated SSL root certs. The CACHE_BUSTER is to allow us to re-generate these
+# images periodically and have them correctly pull new certificates even when
+# there are no meaningful changes in the Dockerfile. You have to bump the
+# CACHE_BUSTER if you haven't changed anything in this file above this line.
+RUN CACHE_BUSTER=1 apt-get install -y ca-certificates
 
 ENV RACK_ENV="production" \
     RAILS_ENV="production" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,6 @@ RUN \
     nodejs
 
 ENV RACK_ENV="production" \
-    RAILS_ENV="production"
+    RAILS_ENV="production" \
+    RAILS_LOG_TO_STDOUT="true" \
+    RAILS_SERVE_STATIC_FILES="true"


### PR DESCRIPTION
> Bump up the gems
> Bump them up
> While your certs are failing
> And the API is bailing
> New Relic's red, the error rate's jumpin'

https://www.youtube.com/watch?v=9EcjWd-O4jI

(technically it's not a gem bump but that rhymed so whatever)

