### PR TITLE
Disable Spring by default via environment variable.

### DIFF
--- a/ruby23.dockerfile
+++ b/ruby23.dockerfile
@@ -42,4 +42,8 @@ ENV RACK_ENV="production" \
     NODE_ENV="production" \
 # Rails 5 new configuration magic
     RAILS_LOG_TO_STDOUT="true" \
-    RAILS_SERVE_STATIC_FILES="true"
+    RAILS_SERVE_STATIC_FILES="true" \
+# Don't use spring under any circumstances. We don't want it, and certain
+# versions also conflict with the BUNDLE_APP_CONFIG that is part of the
+# official Ruby image
+    DISABLE_SPRING="true"

--- a/ruby25.dockerfile
+++ b/ruby25.dockerfile
@@ -42,4 +42,8 @@ ENV RACK_ENV="production" \
     NODE_ENV="production" \
 # Rails 5 new configuration magic
     RAILS_LOG_TO_STDOUT="true" \
-    RAILS_SERVE_STATIC_FILES="true"
+    RAILS_SERVE_STATIC_FILES="true" \
+# Don't use spring under any circumstances. We don't want it, and certain
+# versions also conflict with the BUNDLE_APP_CONFIG that is part of the
+# official Ruby image
+    DISABLE_SPRING="true"


### PR DESCRIPTION
See comment in this commit for reasoning. Basically, spring was breaking
binstubs, which was breaking Rails console in production. I didn't
realize we were even using Spring, so we don't want it regardless since
we are not reloading the environment ever in the Docker container.