### PR TITLE
Install jemalloc, but don't make it the default.

### DIFF
--- a/ruby23.dockerfile
+++ b/ruby23.dockerfile
@@ -27,6 +27,9 @@ RUN \
     yarn \
 # gives us nslookup and friends for the CI pipeline
     dnsutils netcat && \
+# alternate memory allocator that plays nicer with larger Ruby applications.
+# Only used if LD_PRELOAD environment variable is set!
+    libjemalloc-dev && \
 # clean up apt cache
   rm -rf /var/lib/apt/lists/*
 

--- a/ruby25.dockerfile
+++ b/ruby25.dockerfile
@@ -27,6 +27,9 @@ RUN \
     yarn \
 # gives us nslookup and friends for the CI pipeline
     dnsutils netcat && \
+# alternate memory allocator that plays nicer with larger Ruby applications.
+# Only used if LD_PRELOAD environment variable is set!
+    libjemalloc-dev && \
 # clean up apt cache
   rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
This feels safest. Let the individual apps opt-in to jemalloc, at least
for now. We could make it the default by setting an environment variable, but I'm going to instead make a new (disabled-by-default) override in the Rails CI Plan.

I have verified before that just installing this package does NOT switch you to jemalloc.

Intended to be enabled in the CI plan with this override: https://github.com/g5search/ci-plan-rails/pull/5